### PR TITLE
단어 저장 테스크 추가

### DIFF
--- a/conf/dev.conf.example
+++ b/conf/dev.conf.example
@@ -12,3 +12,4 @@ URL = https://opendict.korean.go.kr/api/
 [WORKER]
 BROKER_URL=redis://localhost:6379/1
 CELERY_RESULT_BACKEND=redis://localhost:6379/2
+celery_imports = ['word_way.scrapping.word']

--- a/conf/prod.conf
+++ b/conf/prod.conf
@@ -12,3 +12,4 @@ URL = https://opendict.korean.go.kr/api/
 [WORKER]
 BROKER_URL=redis://localhost:6379/1
 CELERY_RESULT_BACKEND=redis://localhost:6379/2
+celery_imports = ['word_way.scrapping.word']

--- a/word_way/context.py
+++ b/word_way/context.py
@@ -1,15 +1,23 @@
 import typing
 
-from flask import request
+from celery import current_task
+from flask import request, has_request_context
 from werkzeug.local import LocalProxy
 
 from word_way.config import current_config
 from word_way.orm import Session, create_engine
 
 
+def current_context():
+    if has_request_context():
+        return request._get_current_object()
+    else:
+        return current_task
+
+
 @LocalProxy
 def session() -> Session:
-    ctx = request._get_current_object()
+    ctx = current_context()
     try:
         session = ctx._current_session
     except AttributeError:

--- a/word_way/scrapping/word.py
+++ b/word_way/scrapping/word.py
@@ -10,11 +10,18 @@ from sqlalchemy import literal
 from sqlalchemy.orm.session import Session
 from urllib.parse import urljoin
 
+from word_way.celery import celery
+from word_way.context import session
 from word_way.config import get_word_api_config
 from word_way.models import Pronunciation, Sentence, Word, WordSentenceAssoc
 from word_way.utils import convert_word_part
 
-__all__ = 'save_word',
+__all__ = 'save_word', 'save_word_task',
+
+
+@celery.task
+def save_word_task(target_word: str):
+    save_word(target_word, session)
 
 
 def save_word(

--- a/word_way/scrapping/word.py
+++ b/word_way/scrapping/word.py
@@ -84,6 +84,7 @@ def save_word(
                 pronunciation_id=pronunciation.id,
             )
             session.add(word)
+            session.flush()
             save_extra_info(word, session)
     session.commit()
     return pronunciation_id
@@ -122,3 +123,4 @@ def save_extra_info(word: Word, session: Session) -> None:
         session.flush()
         assoc = WordSentenceAssoc(word_id=word.id, sentence_id=sentence.id)
         session.add(assoc)
+        session.flush()


### PR DESCRIPTION
# tldr;

단어 저장 비동기 처리를 위해 테스크 생성

# 주요 변경 기록

- celery에서도 session 사용 가능하도록
  - current_task 함수 추가
- 단어 정보 저장 함수를 실행하는 task 생성
- 단어 정보 저장 함수 안에 빠진 session.flush() 추가
  - task 실행하면 IntegrityError가 나길래 추가했습니다. (task 아닐 때는 안 나는데 🤔)


https://github.com/word-way/word-way-backend/blob/26e7b881cfb96fd56ee80b92fddcb94f19a65c75/init_word.py#L60 기존에 save_word()를 사용하던 부분이 아직 이 부분밖에 없는데 여기서는 비동기로 실행 하지 않는 게 오히려 나을 것 같아서 그대로 뒀습니다. 

# 실행 스크린샷

아래 코드로 잘 저장되는지 확인했습니다.
```diff
diff --git a/word_way/api/__init__.py b/word_way/api/__init__.py
index 180bf6c..477fe29 100644
--- a/word_way/api/__init__.py
+++ b/word_way/api/__init__.py
@@ -3,6 +3,8 @@
 """
 from flask import Blueprint

+from word_way.scrapping.word import save_word_task
+
 __all__ = 'api', 'ping',


@@ -11,4 +13,5 @@ api = Blueprint('api', __name__)

 @api.route('/ping/', methods=['GET'])
 def ping():
+    save_word_task.delay('사과')
     return 'pong'
```
<img width="1224" alt="단어 정보" src="https://user-images.githubusercontent.com/22957868/78472548-cef07c00-7774-11ea-9b58-531254edd183.png">
