### PR TITLE
[Feat/#17] 단어 검색을 위한 API 핸들러 추가하기

### DIFF
--- a/word_way/api/constant.py
+++ b/word_way/api/constant.py
@@ -1,0 +1,1 @@
+API_PRE_PATH = '/api'

--- a/word_way/api/word.py
+++ b/word_way/api/word.py
@@ -1,0 +1,105 @@
+""":mod:`word_way.api.word` --- Word API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+from flask import Blueprint, jsonify
+
+from word_way.api.constant import API_PRE_PATH
+from word_way.api.serializer import serialize
+from word_way.context import session
+
+__all__ = 'api',
+
+from word_way.models import Pronunciation
+
+api = Blueprint('word', __name__, url_prefix=f'{API_PRE_PATH}/words')
+
+
+@api.route('/', methods=['GET'])
+def search_words():
+    """
+
+    [GET] /api/words/
+
+    Arguments
+        words: ["분리하다", "절단하다", "떨어지다", "분리"]
+
+    Response
+        [
+            {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "pronunciation": "떼다",
+                "words": [
+                    {
+                        "id": "00000000-0000-0000-0000-000000000001",
+                        "contents": "붙어 있거나 잇닿은 것을 떨어지게 하다.",
+                        "part": "verb",
+                        "related_pronunciations": ["잇닿은", "떨어지게 하다"]
+                    },
+                    {
+                        "id": "00000000-0000-0000-0000-000000000002",
+                        "contents": "남에게서 빌려 온 돈 따위를 돌려주지 않다.",
+                        "part": "verb",
+                        "related_pronunciations": ["남", "돈"]
+                    }
+                ],
+                "related_pronunciations": []
+            },
+            {
+                "id": "00000000-0000-0000-0000-000000000002",
+                "pronunciation": "꺾다",
+                "words": [
+                    {
+                        "id": "00000000-0000-0000-0000-000000000003",
+                        "contents": "길고 탄력이 있거나 단단한 물체를 구부려...",
+                        "part": "verb",
+                        "related_pronunciations": []
+                    }
+                ]
+                "related_words": ["나아가다", "진보하다"]
+            }
+        ]
+
+        NOTE 1: related_pronunciations 유의어
+        NOTE 2: words.related_pronunciations 포함어
+        NOTE 3: words length가 2 이상일 경우 동음이의어
+        NOTE 4: words length가 1 미만일 경우 조회 X
+
+        ** 검색 결과 순서
+        - 검색어와 동일한 발음을 가진 단어 (:class:`Word`)
+            : select * from pronunciation where pronunciation like '%단어%';
+        - 검색어가 유의어에 포함된 단어 (:class:`SynonymsWordRelation`)
+            : select * from pronunciation where id in (
+                select criteria_id from synonyms_word_relation
+                where related_id = (
+                    select id from pronunciation where pronunciation = '단어'
+                )
+            );
+        - 검색어가 의미에 포함된 단어 (:class:`IncludeWordRelation`)
+            : select * from word where id in (
+                select criteria_id from include_word_relation
+                where related_id in (
+                    select id from pronunciation where pronunciation = '단어'
+                )
+            );
+
+    """
+    pronunciations = session.query(Pronunciation).all()
+
+    return jsonify(
+        serialize([
+            {
+                'id': p.id,
+                'pronunciation': p.pronunciation,
+                'words': [
+                    {
+                        'id': word.id,
+                        'contents': word.contents,
+                        'part': word.part,
+                        'related_pronunciations':
+                            word.related_include_pronunciations,
+                    } for word in p.words
+                ],
+                'related_words': p.related_synonyms_pronunciations,
+            } for p in pronunciations
+        ])
+    )

--- a/word_way/app.py
+++ b/word_way/app.py
@@ -5,6 +5,7 @@ from flask import Flask
 from typeguard import typechecked
 
 from word_way.api import api
+from word_way.api.word import api as word_api
 from word_way.config import load_config
 
 __all__ = 'create_app',
@@ -14,6 +15,7 @@ __all__ = 'create_app',
 def create_app(config_name: str) -> Flask:
     app = Flask(__name__)
     app.register_blueprint(api)
+    app.register_blueprint(word_api)
     config = load_config(config_name)
     app.config.update(config['WEB'])
     app.config['APP_CONFIG'] = config

--- a/word_way/models.py
+++ b/word_way/models.py
@@ -1,3 +1,4 @@
+import typing
 import uuid
 
 from sqlalchemy import Column, ForeignKey, Integer, Unicode, UniqueConstraint
@@ -33,6 +34,15 @@ class Pronunciation(Base):
     #: (:class:`str`) 발음
     pronunciation = Column(Unicode, unique=True, nullable=False)
 
+    words = relationship('Word', uselist=True, back_populates='pronunciation')
+
+    word_relation = relationship(
+        'SynonymsWordRelation',
+        uselist=True,
+        primaryjoin="SynonymsWordRelation.criteria_id==Pronunciation.id",
+        back_populates='criteria_words',
+    )
+
     __tablename__ = 'pronunciation'
 
 
@@ -57,7 +67,18 @@ class Word(Base):
     )
 
     #: (:class:`Pronunciation`) 발음
-    pronunciation = relationship(Pronunciation, uselist=False)
+    pronunciation = relationship(
+        Pronunciation,
+        uselist=False,
+        back_populates='words',
+    )
+
+    word_relation = relationship(
+        'IncludeWordRelation',
+        uselist=True,
+        primaryjoin="IncludeWordRelation.criteria_id == Word.id",
+        back_populates='criteria_words',
+    )
 
     __tablename__ = 'word'
 
@@ -135,6 +156,19 @@ class SynonymsWordRelation(WordRelation):
         ForeignKey(Pronunciation.id),
     )
 
+    criteria_words = relationship(
+        Pronunciation,
+        uselist=False,
+        foreign_keys=[criteria_id],
+        backref='word_relations',
+    )
+
+    related_pronunciations = relationship(
+        Pronunciation,
+        uselist=True,
+        foreign_keys=[relation_id],
+    )
+
     __table_args__ = (
         UniqueConstraint(
             'pronunciation_id',
@@ -160,6 +194,19 @@ class IncludeWordRelation(WordRelation):
         'related_pronunciation_id',
         UUIDType,
         ForeignKey(Pronunciation.id),
+    )
+
+    criteria_words = relationship(
+        Word,
+        uselist=False,
+        foreign_keys=[criteria_id],
+        backref='word_relations',
+    )
+
+    related_pronunciations = relationship(
+        Pronunciation,
+        uselist=True,
+        foreign_keys=[relation_id],
     )
 
     __table_args__ = (

--- a/word_way/models.py
+++ b/word_way/models.py
@@ -43,6 +43,15 @@ class Pronunciation(Base):
         back_populates='criteria_words',
     )
 
+    @property
+    def related_synonyms_pronunciations(self) -> typing.Sequence[str]:
+        pronunciation = []
+        for relation in self.word_relation:
+            pronunciation += [
+                p.pronunciation for p in relation.related_pronunciations
+            ]
+        return pronunciation
+
     __tablename__ = 'pronunciation'
 
 
@@ -79,6 +88,15 @@ class Word(Base):
         primaryjoin="IncludeWordRelation.criteria_id == Word.id",
         back_populates='criteria_words',
     )
+
+    @property
+    def related_include_pronunciations(self) -> typing.Sequence[str]:
+        pronunciation = []
+        for relation in self.word_relation:
+            pronunciation += [
+                p.pronunciation for p in relation.related_pronunciations
+            ]
+        return pronunciation
 
     __tablename__ = 'word'
 


### PR DESCRIPTION
검색 API 명세를 정의하고, 해당 명세에 맞게 결과가 나올 수 있도록 틀만 먼저 다져두었습니다.

아직 검색 엔진은 추가하지 않아서 일단 모든 발은에 대한 저보를 리턴할 수 있도록 해두었습니다.

> 검색 결과 API response
![image](https://user-images.githubusercontent.com/26541456/80694170-17e6e680-8b0f-11ea-8a94-181e901c5d31.png)


