### PR TITLE
단어가 없는 발음을 기준으로 단어를 추가하는 테스크 추가하기

### DIFF
--- a/word_way/migrations/versions/6013d366a3a0_add_scrapped_at_to_pronunciation.py
+++ b/word_way/migrations/versions/6013d366a3a0_add_scrapped_at_to_pronunciation.py
@@ -1,0 +1,25 @@
+"""Add scrapped_at to Pronunciation
+
+Revision ID: 6013d366a3a0
+Revises: 94abc68d90ce
+Create Date: 2020-10-11 16:39:21.931294
+
+"""
+from alembic import op
+from sqlalchemy import Column, DateTime
+
+revision = '6013d366a3a0'
+down_revision = '94abc68d90ce'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'pronunciation',
+        Column('scrapped_at', DateTime(timezone=True), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column('pronunciation', 'scrapped_at')

--- a/word_way/models.py
+++ b/word_way/models.py
@@ -1,7 +1,9 @@
 import typing
 import uuid
 
-from sqlalchemy import Column, ForeignKey, Integer, Unicode, UniqueConstraint
+from sqlalchemy import (
+    Column, DateTime, ForeignKey, Integer, Unicode, UniqueConstraint
+)
 from sqlalchemy.orm import relationship
 from sqlalchemy_enum34 import EnumType
 from sqlalchemy_utils.types.uuid import UUIDType
@@ -33,6 +35,9 @@ class Pronunciation(Base):
 
     #: (:class:`str`) 발음
     pronunciation = Column(Unicode, unique=True, nullable=False)
+
+    #: (:class:`datetime.datetime`) 발음에 해당하는 단어들을 스크래핑한 시각
+    scrapped_at = Column(DateTime(timezone=True))
 
     words = relationship('Word', uselist=True, back_populates='pronunciation')
 

--- a/word_way/utils.py
+++ b/word_way/utils.py
@@ -1,4 +1,8 @@
+import datetime
+
 from word_way.enum import WordPart
+
+__all__ = ('convert_word_part', 'utc_now',)
 
 
 def convert_word_part(part: str):
@@ -12,3 +16,7 @@ def convert_word_part(part: str):
         '부사': WordPart.adverb,
         '감탄사': WordPart.interjection,
     }.get(part, WordPart.unknown)
+
+
+def utc_now():
+    return datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)


### PR DESCRIPTION
# tldr;

단어가 없는 발음을 기준으로 단어를 추가하는 테스크 추가하기

# 주요 변경 사항

단어가 없는 발음을 가져와서 단어를 추가하는 save_words_task 테스크를 추가합니다.
- Pronunciation에 scrapped_at 컬럼 추가
- 스크래핑할 때 해당 컬럼 업데이트
- scrapped_at == null && 단어가 없는 발음으로 검색