### PR TITLE
[#50] 검색 API 구체화 #3

### DIFF
--- a/word_way/api/word.py
+++ b/word_way/api/word.py
@@ -1,6 +1,8 @@
 """:mod:`word_way.api.word` --- Word API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
+from typing import List, Optional, Tuple
+
 from flask import Blueprint, jsonify, request
 from flask_restx import Api, Resource, fields
 from sqlalchemy import or_, literal
@@ -8,10 +10,14 @@ from sqlalchemy import or_, literal
 from word_way.api.constant import API_PRE_PATH
 from word_way.api.serializer import serialize
 from word_way.context import session
+from word_way.models import (
+    IncludeWordRelation,
+    Pronunciation,
+    SynonymsWordRelation,
+    Word,
+)
 
 __all__ = 'blueprint',
-
-from word_way.models import Pronunciation, SynonymsWordRelation
 
 blueprint = Blueprint('word', __name__, url_prefix=f'{API_PRE_PATH}/words')
 api = Api(blueprint, doc='/doc/')
@@ -28,6 +34,61 @@ parser.add_argument(
 class WordApi(Resource):
     from word_way.api.type import pronunciationList
 
+    @staticmethod
+    def serialize_response(
+        pronunciation: Pronunciation,
+        words: List[Word],
+        priority: int,
+    ) -> dict:
+        p = pronunciation
+
+        return {
+            'id': p.id,
+            'pronunciation': p.pronunciation,
+            'words': [
+                {
+                    'id': word.id,
+                    'contents': word.contents,
+                    'part': word.part,
+                    'related_pronunciations':
+                        word.related_include_pronunciations,
+                } for word in words
+            ],
+            'related_words': p.related_synonyms_pronunciations,
+            'priority': priority,
+        }
+
+    @staticmethod
+    def distinct_pronunciation(serialized_response: List[dict]):
+        pronunciation_ids = set()
+        distinct_items = []
+        for res in serialized_response:
+            pronunciation_id = res['id']
+            if pronunciation_id in pronunciation_ids:
+                continue
+            distinct_items.append(res)
+            pronunciation_ids.add(pronunciation_id)
+        return distinct_items
+
+    def make_response(
+        self,
+        pronunciations: List[Tuple[Pronunciation, int]],
+        words: Optional[List[Tuple[Word, int]]] = None,
+    ):
+        response = [
+            self.serialize_response(p, p.words, priority)
+            for p, priority in pronunciations
+        ]
+        if words:
+            response += [
+                self.serialize_response(word.pronunciation, [word], priority)
+                for word, priority in words
+            ]
+
+        return jsonify(
+            data=serialize(self.distinct_pronunciation(response))
+        )
+
     @api.expect(parser)
     @api.response(200, '성공. 단어 검색 결과', model=pronunciationList)
     def get(self):
@@ -43,21 +104,17 @@ class WordApi(Resource):
             - 검색어와 동일한 발음을 가진 단어 (:class:`Word`)
             - 검색어가 유의어에 포함된 단어 (:class:`SynonymsWordRelation`)
             - 검색어가 의미에 포함된 단어 (:class:`IncludeWordRelation`)
-                : select * from word where id in (
-                    select criteria_id from include_word_relation
-                    where related_id in (
-                        select id from pronunciation where pronunciation = '단어'
-                    )
-                );
 
         """
         keywords = request.args.getlist('keywords')
         query = session.query(Pronunciation)
+        words = None
 
         if keywords:
             base_query = query
             order_column = 'priority'
 
+            # 검색어와 동일한 발음을 가진 단어
             word_query = base_query.filter(
                 or_(*[
                     Pronunciation.pronunciation.like(f'%{keyword.strip()}%')
@@ -65,6 +122,7 @@ class WordApi(Resource):
                 ]),
             ).add_column(literal(0).label(order_column))
 
+            # 검색어가 유의어에 포함된 단어
             synonyms_query = base_query.filter(
                 Pronunciation.id.in_(
                     session.query(SynonymsWordRelation.criteria_id).filter(
@@ -77,22 +135,16 @@ class WordApi(Resource):
 
             query = word_query.union(synonyms_query).order_by(order_column)
 
+            # 검색어가 의미에 포함된 단어
+            words = session.query(Word, literal(2).label(order_column)).filter(
+                Word.id.in_(
+                    session.query(IncludeWordRelation.criteria_id).filter(
+                        IncludeWordRelation.related_pronunciations.any(
+                            Pronunciation.pronunciation.in_(keywords)
+                        ),
+                    ).subquery()
+                )
+            ).all()
+
         pronunciations = query.all()
-        return jsonify(
-            data=serialize([
-                {
-                    'id': p.id,
-                    'pronunciation': p.pronunciation,
-                    'words': [
-                        {
-                            'id': word.id,
-                            'contents': word.contents,
-                            'part': word.part,
-                            'related_pronunciations':
-                                word.related_include_pronunciations,
-                        } for word in p.words
-                    ],
-                    'related_words': p.related_synonyms_pronunciations,
-                } for p, _ in pronunciations
-            ])
-        )
+        return self.make_response(pronunciations, words)


### PR DESCRIPTION
- 검색어가 단어의 의미에 포함되는 경우 리턴해줍니다.
- 여러 조건에 모두 포함되는 경우 중복 제거 해줍니다.
  - 이 때 더 높은 우선순위의 필터를 남기고 남은 것을 제외시킵니다.

## 예시

> 마음

![image](https://user-images.githubusercontent.com/26541456/95673531-3683fa00-0be4-11eb-80bf-281d564453cb.png)

> 애착

![image](https://user-images.githubusercontent.com/26541456/95673549-5b786d00-0be4-11eb-842e-e2c7f874ab8d.png)


> 애착 & 마음

![image](https://user-images.githubusercontent.com/26541456/95673539-48fe3380-0be4-11eb-93e3-d09881efa8bb.png)


## 추가된 쿼리

```
SELECT 
  word.id AS word_id, word.target_code AS word_target_code, word.part AS word_part, word.contents AS word_contents, word.pronunciation_id AS word_pronunciation_id, %(param_1)s AS priority 
FROM word 
WHERE word.id IN (
  SELECT include_word_relation.word_id 
  FROM word_relation
  JOIN include_word_relation ON word_relation.id = include_word_relation.id 
  WHERE EXISTS (
    SELECT 1 
    FROM pronunciation 
    WHERE pronunciation.id = include_word_relation.related_pronunciation_id 
    AND pronunciation.pronunciation IN (%(pronunciation_1)s)
  )
)
```